### PR TITLE
Add tests for Get/Set-SearchCatalog

### DIFF
--- a/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/CommandTestBase.cs
+++ b/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/CommandTestBase.cs
@@ -43,6 +43,8 @@ public class CommandTestBase
         // Avoid accidental issues with confirmation. We use -WhatIf for ShouldProcess() testing and assert
         // the ConfirmImpact property of the CmdletAttribute for selected commands.
         PowerShell.Runspace.SessionStateProxy.SetVariable("ConfirmPreference", ConfirmImpact.None);
+        // 'Continue' is default, but make it explicit.
+        PowerShell.Runspace.SessionStateProxy.SetVariable("ErrorActionPreference", ActionPreference.Continue);
     }
 
     protected readonly MockInterfaceChain InterfaceChain;

--- a/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/SearchCatalogCommandsTests.cs
+++ b/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/SearchCatalogCommandsTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2023 Matthias Wolf, Mawosoft.
+
+namespace Mawosoft.PowerShell.WindowsSearchManager.Tests;
+
+public class SearchCatalogCommandsTests : CommandTestBase
+{
+    private class MockSearchManagerWithMultipleCatalogs : MockSearchManager2
+    {
+        internal List<ISearchCatalogManager> CatalogManagers { get; set; }
+
+        public MockSearchManagerWithMultipleCatalogs() : base()
+        {
+            CatalogManagers = new()
+            {
+                new MockCatalogManagerWithGetSetException(),
+                new MockCatalogManagerWithGetSetException()
+                {
+                    Name = "FooCatalog",
+                    Status = _CatalogStatus.CATALOG_STATUS_INCREMENTAL_CRAWL,
+                    PausedReason = _CatalogPausedReason.CATALOG_PAUSED_REASON_NONE
+                },
+                new MockCatalogManagerWithGetSetException()
+                {
+                    Name = "BarCatalog",
+                    NumberOfItemsInternal = 2222,
+                    DiacriticSensitivity = 1
+                }
+            };
+        }
+
+        public override ISearchCatalogManager GetCatalog(string pszCatalog)
+        {
+            if (CatalogManagerException != null) throw CatalogManagerException;
+            for (int i = 0; i < CatalogManagers.Count; i++)
+            {
+                if (pszCatalog == CatalogManagers[i].Name) return CatalogManagers[i];
+            }
+            throw new COMException(null, unchecked((int)0x80042103)); // MSS_E_CATALOGNOTFOUND
+        }
+    }
+
+    private class MockCatalogManagerWithGetSetException : MockCatalogManager
+    {
+        internal Exception? GetException { get; set; }
+        internal Exception? SetException { get; set; }
+
+        public override uint ConnectTimeout
+        {
+            get => GetException == null ? base.ConnectTimeout : throw GetException;
+            set
+            {
+                if (SetException != null) throw SetException;
+                base.ConnectTimeout = value;
+            }
+        }
+        public override uint DataTimeout
+        {
+            get => GetException == null ? base.DataTimeout : throw GetException;
+            set
+            {
+                if (SetException != null) throw SetException;
+                base.DataTimeout = value;
+            }
+        }
+        public override int DiacriticSensitivity
+        {
+            get => GetException == null ? base.DiacriticSensitivity : throw GetException;
+            set
+            {
+                if (SetException != null) throw SetException;
+                base.DiacriticSensitivity = value;
+            }
+        }
+
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("FooCatalog", false)]
+    [InlineData("BarCatalog", true)]
+    public void GetSearchCatalog_Succeeds(string? catalogName, bool positional)
+    {
+        MockSearchManagerWithMultipleCatalogs searchManager = new();
+        InterfaceChain.WithSearchManager(searchManager);
+        List<ISearchCatalogManager> expected = searchManager.CatalogManagers;
+        InterfaceChain.Factory.SearchRegistryProvider.CatalogNames = searchManager.CatalogManagers.ConvertAll(c => c.Name);
+        string script = "Get-SearchCatalog ";
+        if (catalogName != null)
+        {
+            if (!positional) script += "-Catalog ";
+            script += $"'{catalogName}' ";
+            expected = expected.FindAll(c => c.Name == catalogName);
+        }
+        PowerShell.AddScript(script);
+        Collection<PSObject> results = PowerShell.Invoke();
+        Assert.All(results, (item, i) => Assert.Equal(expected[i], item.BaseObject, SearchCatalogInfoToMockComparer.Instance));
+        Assert.Equal(expected.Count, results.Count);
+        Assert.False(PowerShell.HadErrors);
+    }
+
+    [Fact]
+    public void GetSearchCatalog_WithFailures_Succeeds()
+    {
+        MockSearchManagerWithMultipleCatalogs searchManager = new();
+        InterfaceChain.WithSearchManager(searchManager);
+        List<ISearchCatalogManager> expected = new(searchManager.CatalogManagers);
+        searchManager.CatalogManagers.Insert(1, new MockCatalogManagerWithGetSetException()
+        {
+            Name = "BadCatalog1",
+            GetException = new Exception()
+        });
+        InterfaceChain.Factory.SearchRegistryProvider.CatalogNames = searchManager.CatalogManagers.ConvertAll(c => c.Name);
+        InterfaceChain.Factory.SearchRegistryProvider.CatalogNames.Insert(2, "NotFound2");
+        PowerShell.AddScript("Get-SearchCatalog");
+        Collection<PSObject> results = PowerShell.Invoke();
+        Assert.All(results, (item, i) => Assert.Equal(expected[i], item.BaseObject, SearchCatalogInfoToMockComparer.Instance));
+        Assert.Equal(expected.Count, results.Count);
+        Assert.True(PowerShell.HadErrors);
+        PSDataCollection<ErrorRecord> errors = PowerShell.Streams.Error;
+        Assert.Collection(errors,
+            e => Assert.Equal("BadCatalog1", e.TargetObject),
+            e => Assert.Equal("NotFound2", e.TargetObject)
+            );
+    }
+
+    [Theory]
+    [ClassData(typeof(Exception_TheoryData))]
+    public void GetCatalogManager_HandlesFailures(ExceptionParam exceptionParam)
+    {
+        InterfaceChain.WithCatalogManager(new MockCatalogManagerWithGetSetException()
+        {
+            GetException = exceptionParam.Value.Exception,
+            SetException = exceptionParam.Value.Exception
+        });
+        PowerShell.AddScript("Get-SearchCatalog");
+        Collection<PSObject> results = PowerShell.Invoke();
+        Assert.Empty(results);
+        AssertSingleErrorRecord(exceptionParam);
+    }
+}

--- a/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/mocks/MockInterfaceChain.cs
+++ b/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/mocks/MockInterfaceChain.cs
@@ -55,7 +55,7 @@ public class MockInterfaceChain
         switch (chainIndex)
         {
             case 0: Factory = null!; ExceptionType = typeof(NullReferenceException); break;
-            case 1: Factory.SearchManager = null; ExceptionType = typeof(COMException); break;
+            case 1: Factory.SearchManager = null!; ExceptionType = typeof(COMException); break;
             case 2: SearchManager.CatalogManager = null; ExceptionType = typeof(COMException); break;
             case 3: CatalogManager.ScopeManager = null; ExceptionType = typeof(COMException); break;
             default:

--- a/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/mocks/MockSearchManagerFactory.cs
+++ b/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/mocks/MockSearchManagerFactory.cs
@@ -5,12 +5,12 @@ namespace Mawosoft.PowerShell.WindowsSearchManager.Tests;
 // Internal members are used to setup mock behavior.
 internal class MockSearchManagerFactory : ISearchManagerFactory
 {
-    internal ISearchManager? SearchManager { get; set; }
+    internal MockSearchManager SearchManager { get; set; }
     internal Exception? SearchManagerException { get; set; }
-    internal ISearchRegistryProvider SearchRegistryProvider { get; set; } = new MockSearchRegistryProvider();
+    internal MockSearchRegistryProvider SearchRegistryProvider { get; set; } = new MockSearchRegistryProvider();
 
     internal MockSearchManagerFactory() : this(new MockSearchManager2()) { }
-    internal MockSearchManagerFactory(ISearchManager? searchManager) => SearchManager = searchManager;
+    internal MockSearchManagerFactory(MockSearchManager searchManager) => SearchManager = searchManager;
 
     public virtual ISearchManager CreateSearchManager()
         => SearchManagerException == null ? SearchManager! : throw SearchManagerException;


### PR DESCRIPTION
* Add Get-SearchCatalog tests.
  - Use class types instead of interfaces in MockSearchManagerFactory.
  - Explicitly set ErrorActionPreference = Continue.
  - Simplify MockSearchManagerWithGetSetException.