### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="docfx" Version="2.63.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.PowerShell.5.1.ReferenceAssemblies" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.2.10" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.2.11" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="platyPS" Version="0.14.2" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
-    <PackageVersion Include="System.Management.Automation" Version="7.2.10" />
+    <PackageVersion Include="System.Management.Automation" Version="7.2.11" />
     <PackageVersion Include="System.ServiceProcess.ServiceController" Version="7.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.202",
+    "version": "7.0.203",
     "rollForward": "disable"
   },
   "msbuild-sdks": {

--- a/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/Mawosoft.PowerShell.WindowsSearchManager.Tests.csproj
+++ b/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/Mawosoft.PowerShell.WindowsSearchManager.Tests.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Update="Microsoft.PowerShell.SDK" VersionOverride="7.3.3" />
-    <PackageReference Update="System.Management.Automation" VersionOverride="7.3.3" />
+    <PackageReference Update="Microsoft.PowerShell.SDK" VersionOverride="7.3.4" />
+    <PackageReference Update="System.Management.Automation" VersionOverride="7.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/mocks/MockCommandRuntime.cs
+++ b/tests/Mawosoft.PowerShell.WindowsSearchManager.Tests/mocks/MockCommandRuntime.cs
@@ -10,7 +10,7 @@ namespace Mawosoft.PowerShell.WindowsSearchManager.Tests;
 // See also https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
 public class MockCommandRuntime : ICommandRuntime
 {
-    internal List<object> Outputs { get; } = new();
+    internal List<object?> Outputs { get; } = new();
     internal List<ErrorRecord> Errors { get; } = new();
 
 #if !NETFRAMEWORK
@@ -29,21 +29,21 @@ public class MockCommandRuntime : ICommandRuntime
         Errors.Add(errorRecord);
     }
 
-    public void WriteObject(object sendToPipeline) => Outputs.Add(sendToPipeline);
+    public void WriteObject(object? sendToPipeline) => Outputs.Add(sendToPipeline);
 
     public PSTransactionContext CurrentPSTransaction => throw new NotImplementedException();
     public PSHost Host => throw new NotImplementedException();
-    public bool ShouldContinue(string query, string caption) => throw new NotImplementedException();
-    public bool ShouldContinue(string query, string caption, ref bool yesToAll, ref bool noToAll) => throw new NotImplementedException();
-    public bool ShouldProcess(string target) => throw new NotImplementedException();
-    public bool ShouldProcess(string target, string action) => throw new NotImplementedException();
-    public bool ShouldProcess(string verboseDescription, string verboseWarning, string caption) => throw new NotImplementedException();
-    public bool ShouldProcess(string verboseDescription, string verboseWarning, string caption, out ShouldProcessReason shouldProcessReason) => throw new NotImplementedException();
+    public bool ShouldContinue(string? query, string? caption) => throw new NotImplementedException();
+    public bool ShouldContinue(string? query, string? caption, ref bool yesToAll, ref bool noToAll) => throw new NotImplementedException();
+    public bool ShouldProcess(string? target) => throw new NotImplementedException();
+    public bool ShouldProcess(string? target, string? action) => throw new NotImplementedException();
+    public bool ShouldProcess(string? verboseDescription, string? verboseWarning, string? caption) => throw new NotImplementedException();
+    public bool ShouldProcess(string? verboseDescription, string? verboseWarning, string? caption, out ShouldProcessReason shouldProcessReason) => throw new NotImplementedException();
 
     public bool TransactionAvailable() => throw new NotImplementedException();
     public void WriteCommandDetail(string text) => throw new NotImplementedException();
     public void WriteDebug(string text) => throw new NotImplementedException();
-    public void WriteObject(object sendToPipeline, bool enumerateCollection) => throw new NotImplementedException();
+    public void WriteObject(object? sendToPipeline, bool enumerateCollection) => throw new NotImplementedException();
     public void WriteProgress(long sourceId, ProgressRecord progressRecord) => throw new NotImplementedException();
     public void WriteProgress(ProgressRecord progressRecord) => throw new NotImplementedException();
     public void WriteVerbose(string text) => throw new NotImplementedException();


### PR DESCRIPTION
- Bump dotnet sdk to 7.0.203.
- Bump coverlet.collector to 6.0.0.
- Bump Microsoft.NET.Test.Sdk to 17.6.2.
- Bump Microsoft.PowerShell.SDK to 7.2.11 / 3.3.4
- Bump System.Management.Automation to 7.2.11 / 3.3.4
- Adjust for Nullability changes in PowerShell. Keep docfx at 2.63.1. (2.67.3 breaks our build).
Closes #41.