### PR TITLE
Upgrade docfx to 2.67.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="docfx" Version="2.63.1" />
+    <PackageVersion Include="docfx" Version="2.67.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.PowerShell.5.1.ReferenceAssemblies" Version="1.0.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.2.11" />

--- a/build/convertPlatyPStoDocFxMarkdown.ps1
+++ b/build/convertPlatyPStoDocFxMarkdown.ps1
@@ -120,7 +120,7 @@ class HelpConverter {
         while ($lines.Count -gt 0 -and -not $lines.Peek().StartsWith('# ', [StringComparison]::Ordinal)) {
             $lines.Dequeue()
         }
-        if ($lines.Count -eq 0) { throw "Level 1 header not found" }
+        if ($lines.Count -eq 0) { throw 'Level 1 header not found' }
         $this.DocfxMarkdown.AppendLine($lines.Dequeue()).AppendLine()
         # Convert help sections. Each section starts with a level 2 header
         for (; ; ) {
@@ -475,11 +475,15 @@ if ($cmdlets -and $cmdlets[0].ModuleName) {
     $moduleName = $cmdlets[0].ModuleName
 }
 [ArrayList]$lines = @(
-    "- name: $moduleName", '  href: index.md', '  items:',
+    '### YamlMime:TableOfContent'
+    'items:'
+    "- name: $moduleName"
+    '  href: index.md'
+    '  items:'
     ($cmdlets | Sort-Object Name).TocItem
 )
 foreach ($toc in $AdditionalTocPath) {
-    $lines.AddRange((Get-Content $toc))
+    $lines.AddRange((Get-Content $toc).Where({ $_[0] -ceq '-' -or $_[0] -ceq ' ' }))
 }
 $lines | Update-Content -Path (Join-Path $Destination 'toc.yml')
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,54 +1,58 @@
 {
-    "metadata": [
+  "metadata": [
+    {
+      "src": [
         {
-            "src": [
-                {
-                    "files": [ "*.csproj" ],
-                    "src": "../src/Mawosoft.PowerShell.WindowsSearchManager"
-                }
-            ],
-            "dest": "api",
-            "filter": "filter.yml",
-            "noRestore": true
+          "files": [
+            "*.csproj"
+          ],
+          "src": "../src/Mawosoft.PowerShell.WindowsSearchManager"
         }
       ],
-    "build": {
-        "content": [
-            {
-                "files": [
-                    "reference/*.md",
-                    "reference/toc.yml",
-                    "api/*",
-                    "toc.yml",
-                    "index.md"
-                ],
-                "exclude": [ "api/toc.yml" ]
-            }
-        ],
-        "dest": "_site",
-        "globalMetadata": {
-            "_appTitle": "Windows Search Manager",
-            "_appFooter": "Copyright &copy; 2023 Matthias Wolf, Mawosoft",
-            "_enableSearch": true,
-            "_enableNewTab": true,
-            "_disableBreadcrumb": true,
-            "_disableContribution": true
-        },
-        "globalMetadataFiles": [],
-        "fileMetadataFiles": [],
-        "template": [
-            "default",
-            "templates/custom"
-        ],
-        "xref": [ "xrefmap-SearchAPI.yml" ],
-        "xrefService": [
-            "https://xref.docs.microsoft.com/query?uid={uid}"
-        ],
-        "postProcessors": [],
-        "markdownEngineName": "markdig",
-        "noLangKeyword": false,
-        "keepFileLink": false,
-        "cleanupCacheHistory": true,
-        "disableGitFeatures": false
+      "dest": "api",
+      "filter": "filter.yml",
+      "noRestore": true
     }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "reference/*.md",
+          "reference/toc.yml",
+          "api/*",
+          "toc.yml",
+          "index.md"
+        ],
+        "exclude": [
+          "api/toc.yml"
+        ]
+      }
+    ],
+    "dest": "_site",
+    "globalMetadata": {
+      "_appTitle": "Windows Search Manager",
+      "_appFooter": "Copyright &copy; 2023 Matthias Wolf, Mawosoft",
+      "_enableSearch": true,
+      "_enableNewTab": true,
+      "_disableBreadcrumb": true,
+      "_disableContribution": true
+    },
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default",
+      "templates/custom"
+    ],
+    "xref": [
+      "xrefmap-SearchAPI.yml",
+      "xrefmap-PowerShell.yml"
+    ],
+    "postProcessors": [],
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": true,
+    "disableGitFeatures": false
+  }
 }

--- a/docs/xrefmap-PowerShell.yml
+++ b/docs/xrefmap-PowerShell.yml
@@ -1,0 +1,11 @@
+### YamlMime:XRefMap
+# This should work automatically even with xrefservice dropped, but doesn't.
+baseUrl: https://learn.microsoft.com/dotnet/api/
+sorted: false # if true and not exactly sorted as DocFx expects, some xrefs will not resolve.
+references:
+- uid: System.Management.Automation.SwitchParameter
+  name: SwitchParameter
+  href: System.Management.Automation.SwitchParameter
+  commentId: T:System.Management.Automation.SwitchParameter
+  fullName: System.Management.Automation.SwitchParameter
+  nameWithType: SwitchParameter


### PR DESCRIPTION
- Add xrefmap-PowerShell.yml Note: docfx has dropped support for xrefservice with >= v2.65.0. Automatic resolve for PowerShell SDK type *should* theoretically work, but doesn't - hence the additional xrefmap.
- Update convertPlatyPStoDocFxMarkdown.ps1 to filter out unwanted lines from secondary ToCs.